### PR TITLE
Concurrent implementation on scripts

### DIFF
--- a/backend/scripts/add_new_bets.js
+++ b/backend/scripts/add_new_bets.js
@@ -99,11 +99,12 @@ async function script() {
     const bets = await fetchBets();
     const new_bets = await parse_api_response(bets);
     console.log(new_bets);
-    let total_added = 0;
-    for (const bet of new_bets) {
-        total_added += await add_new_bet(bet);
-    }
-    console.log('Added ', total_added, ' new bets');
+
+    const results = await Promise.allSettled(new_bets.map(add_new_bet));
+
+    const total_added = results.filter(result => result.status === "fulfilled" && result.value === 1).length;
+    console.log('Added', total_added, 'new bets');
 }
+
 
 script();

--- a/backend/scripts/update_bets.js
+++ b/backend/scripts/update_bets.js
@@ -78,13 +78,17 @@ async function parse_api_response(scores) {
 async function script() {
     const scores = await fetchScores();
     const new_bet_winner_pairs = await parse_api_response(scores);
-    let total_updated = 0;
-    for (const pair of new_bet_winner_pairs) {
-        total_updated += await update_winner(pair.bet_id, pair.winner);
-    }
+
     console.log("Number of fetched bets: ", new_bet_winner_pairs.length);
     console.log(new_bet_winner_pairs);
-    console.log('Updated ', total_updated, ' bets');
+
+    const results = await Promise.allSettled(
+        new_bet_winner_pairs.map(pair => update_winner(pair.bet_id, pair.winner))
+    );
+
+    const total_updated = results.filter(result => result.status === "fulfilled" && result.value === 1).length;
+
+    console.log('Updated', total_updated, 'bets');
 }
 
 script();

--- a/backend/scripts/update_bets.js
+++ b/backend/scripts/update_bets.js
@@ -8,7 +8,9 @@ import API_BASE_URL from "../API_BASE_URL.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 // Load environment variables from the .env file
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
+if (process.env.NODE_ENV !== 'production') {
+    dotenv.config({ path: path.resolve(__dirname, '../.env') });
+}
 
 const ODDS_API_URL_NBA = 'https://api.the-odds-api.com/v4/sports/basketball_nba/scores/'
 const ODDS_API_KEY = process.env.ODDS_API_KEY;


### PR DESCRIPTION
Concurrently update bets instead of waiting for looping all the items. Saves a lot of time.

This change does not affect MVP or current deployment.